### PR TITLE
build(docker): set up multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,71 @@
-FROM python:alpine
+#####
+### STAGE 1: Pull latest source
+#####
+FROM alpine:latest AS git-fetch
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
+## Set the repository used to pull the sopel source
+# Set Docker build-arg SOPEL_REPO with private fork, or change default below 
+# as desired. Any valid Git URL is acceptable.
+ARG SOPEL_REPO=https://github.com/sopel-irc/sopel.git
+##
 
-RUN adduser -S sopel
+## Set the specific branch/commit for the source
+# This can be a branch name, release/tag, or even specific commit hash.
+# Set Docker build-arg SOPEL_BRANCH, or replace the default value below.
+ARG SOPEL_BRANCH=master
+##
 
-COPY requirements.txt /usr/src/app/
-RUN pip install --no-cache-dir -r requirements.txt
+RUN set -ex \
+  && apk add --no-cache --virtual .git \
+    git \
+  && git clone \
+    --depth 1 --branch ${SOPEL_BRANCH} \
+    ${SOPEL_REPO} /sopel-src \
+  && apk del \
+    .git
+#####
+#####
 
-COPY . /usr/src/app
+#####
+### STAGE 2: Install Sopel
+#####
+
+## Set the python image tag to use as the base image. 
+# See https://hub.docker.com/_/python?tab=tags for a list of valid tags.
+# Set  default below to desired Python version.
+FROM python:3-alpine
+
+## Set the UID/GID that sopel will run and make files/folders as.
+# For security, these values are set past the upper limit of named users in most
+# linux environments. `chown` any volume mounts to the IDs specified here, or 
+# change to match your GID (and UID if desired) if you think its okay ¯\_(ツ)_/¯
+ARG SOPEL_GID=100000
+ARG SOPEL_UID=100000
+##
+
+RUN set -ex \
+  && apk add --no-cache \
+    enchant \
+\
+  && addgroup -g ${SOPEL_GID} sopel \
+  && adduser -u ${SOPEL_UID} -G sopel -h /home/sopel sopel -D
+
 
 USER sopel
+WORKDIR /home/sopel
 
-# OS X users will crash with permission errors if they use a
-#     volume over /home/sopel/.sopel - nothing we can do about it.
-# Workaround: Don't use OS X
-# https://github.com/boot2docker/boot2docker/issues/581
-# https://github.com/docker/kitematic/issues/351
-VOLUME [ "/home/sopel/.sopel" ]
+COPY --from=git-fetch --chown=sopel:sopel /sopel-src /home/sopel/sopel-src
+RUN set -ex \
+  ## If using a Python 2 based base-image, make sure to install the required
+  ## dependencies (uncomment below)
+  # && pip install --user \
+  #   backports.ssl_match_hostname \
+  && cd ./sopel-src \
+  && python setup.py install --user \
+  && cd .. \
+  && rm -rf ./sopel-src
 
-CMD [ "python", "./sopel.py" ]
+ENV PATH="/home/sopel/.local/bin:${PATH}"
+
+VOLUME [ "/home/sopel" ]
+CMD [ "sopel" ]


### PR DESCRIPTION
Separates source aquisition and installation images. This leads to
a smaller final image, and easier customization for those who wish
to use Docker with their own personal forks, or for testing purposes.

For now, defaults to Python 3 environment, but can be easily change to
use Python 2 if a user needs to based on modules.

Also, fixes #2.

Build details:
```
$ docker images test/sopel
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
3801824bf12b        12 minutes ago      /bin/sh -c #(nop)  CMD ["sopel"]                0B
aa03a74e255f        12 minutes ago      /bin/sh -c #(nop)  VOLUME [/home/sopel]         0B
48dee8733e5d        12 minutes ago      /bin/sh -c #(nop)  ENV PATH=/home/sopel/.loc…   0B
423ae5254ead        12 minutes ago      |2 SOPEL_GID=100000 SOPEL_UID=100000 /bin/sh…   12.4MB
2238288585d5        13 minutes ago      /bin/sh -c #(nop) COPY --chown=sopel:sopeldi…   734kB
635c10f5f32c        13 minutes ago      /bin/sh -c #(nop) WORKDIR /home/sopel           0B
820afddd8649        13 minutes ago      /bin/sh -c #(nop)  USER sopel                   0B
f2d532868f68        13 minutes ago      |2 SOPEL_GID=100000 SOPEL_UID=100000 /bin/sh…   8.03MB
a854686ba399        5 hours ago         /bin/sh -c #(nop)  ARG SOPEL_UID=100000         0B
30e42f41eb94        5 hours ago         /bin/sh -c #(nop)  ARG SOPEL_GID=100000         0B
1a8edcb29ce4        2 weeks ago         /bin/sh -c #(nop)  CMD ["python3"]              0B
<missing>           2 weeks ago         /bin/sh -c set -ex;   wget -O get-pip.py 'ht…   5.93MB
<missing>           2 weeks ago         /bin/sh -c #(nop)  ENV PYTHON_PIP_VERSION=18…   0B
<missing>           2 weeks ago         /bin/sh -c cd /usr/local/bin  && ln -s idle3…   32B
<missing>           2 weeks ago         /bin/sh -c set -ex  && apk add --no-cache --…   67.6MB
<missing>           2 weeks ago         /bin/sh -c #(nop)  ENV PYTHON_VERSION=3.7.2     0B
<missing>           3 weeks ago         /bin/sh -c #(nop)  ENV GPG_KEY=0D96DF4D4110E…   0B
<missing>           3 weeks ago         /bin/sh -c apk add --no-cache ca-certificates   556kB
<missing>           3 weeks ago         /bin/sh -c #(nop)  ENV LANG=C.UTF-8             0B
<missing>           3 weeks ago         /bin/sh -c #(nop)  ENV PATH=/usr/local/bin:/…   0B
<missing>           3 weeks ago         /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
<missing>           3 weeks ago         /bin/sh -c #(nop) ADD file:2ff00caea4e83dfad…   4.41MB
```
`enchant` is huge! >2/3 of the final image size is just from installing the `enchant` lib :cry: 