### PR TITLE
feat: add entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,4 +99,8 @@ RUN set -ex \
 ENV PATH="/home/sopel/.local/bin:${PATH}"
 
 VOLUME [ "/home/sopel" ]
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "sopel" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Run `sopel` with the provided arguments
+if [ "${#}" -eq 0 ] || [ $"{1#-}" != "${1}" ]; then
+  set -- sopel "${@}"
+fi
+
+# OR, just run sopel
+if [ "${1}" = "sopel" ]; then
+  exec sopel
+fi
+
+# Otherwise, try to run what the user specified.
+exec "${@}"

--- a/hooks/build
+++ b/hooks/build
@@ -10,15 +10,21 @@ set -ex
 PYTHON_TAG=${PYTHON_TAG:-3.4-alpine}
 SOPEL_BRANCH=${SOPEL_BRANCH:-v6.6.0}
 
+# Prevent cache busting during development builds by allowing build-specific
+# ARGs to be set by environment variables.
+BUILD_DATE=${BUILD_DATE:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}
+VCF_REF=${VCF_REF:-$(\
+  git ls-remote https://github.com/sopel-irc/sopel \
+    | grep "${SOPEL_BRANCH}" \
+    | head -n 1 \
+    | head -c 7 \
+)}
+
 docker build \
   --build-arg PYTHON_TAG="${PYTHON_TAG}" \
   --build-arg SOPEL_BRANCH="${SOPEL_BRANCH}" \
-  --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-  --build-arg VCS_REF=$(\
-    git ls-remote https://github.com/sopel-irc/sopel \
-      | grep "${SOPEL_BRANCH}" \
-      | head -n 1 \
-      | head -c 7) \
+  --build-arg BUILD_DATE=${BUILD_DATE} \
+  --build-arg VCS_REF=${VCF_REF} \
   --build-arg DOCKERFILE_VCS_REF=`git rev-parse --short HEAD` \
   -f "${DOCKERFILE_PATH}" \
   -t "${IMAGE_NAME}" .


### PR DESCRIPTION
Adds entrypoint to image to provide a simple, consistent interface in line
with the Docker philosophy: "A beginning user should be able to
`docker run sopelirc/sopel bash` (or `sh`) without needing to learn about
`--entrypoint`. It is also nice for advanced users to take advantage of
`entrypoint`, so that they can `docker run sopelirc/sopel --arg1 --arg2`
 without having to specify the binary to execute."

Also, this commit moves the build-specific ARGs (e.g., `BUILD_DATE`)
out of the `docker build` command to allow for cache-bust preventing
hack-y monkey business. See the comment in `hooks/build` for more details.