### PR TITLE
fix: make .sopel directory during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,10 @@ RUN set -ex \
     enchant \
 \
   && addgroup -g ${SOPEL_GID} sopel \
-  && adduser -u ${SOPEL_UID} -G sopel -h /home/sopel sopel -D
+  && adduser -u ${SOPEL_UID} -G sopel -h /home/sopel sopel -D \
+\
+  && mkdir /home/sopel/.sopel \
+  && chown sopel:sopel /home/sopel/.sopel
 
 USER sopel
 WORKDIR /home/sopel


### PR DESCRIPTION
Mounts to `~/.sopel` will cause `sopel` to error because `~/.sopel` will be
owned by `root`. Since we change to user `sopel` during build, there is no
way to change permissions from `ENTRYPOINT`. So, let just make the dir during
build.

Fixes #7