### PR TITLE
refactor/fix: build as root, run as sopel; allow id changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ ARG SOPEL_UID
 
 RUN set -ex \
   && apk add --no-cache \
+    shadow \
     su-exec \
     enchant \
 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,15 +77,15 @@ ARG SOPEL_UID
 
 RUN set -ex \
   && apk add --no-cache \
+    su-exec \
     enchant \
 \
   && addgroup -g ${SOPEL_GID} sopel \
-  && adduser -u ${SOPEL_UID} -G sopel -h /home/sopel sopel -D \
+  && adduser -u ${SOPEL_UID} -G sopel -h /home/sopel -s /bin/ash sopel -D \
 \
   && mkdir /home/sopel/.sopel \
   && chown sopel:sopel /home/sopel/.sopel
 
-USER sopel
 WORKDIR /home/sopel
 
 COPY --from=git-fetch --chown=sopel:sopel /sopel-src /home/sopel/sopel-src
@@ -95,11 +95,9 @@ RUN set -ex \
   # && pip install --user \
   #   backports.ssl_match_hostname \
   && cd ./sopel-src \
-  && python setup.py install --user \
+  && su-exec sopel python setup.py install --user \
   && cd .. \
   && rm -rf ./sopel-src
-
-ENV PATH="/home/sopel/.local/bin:${PATH}"
 
 VOLUME [ "/home/sopel" ]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,19 @@
 #!/bin/sh
 set -e
 
+export PATH="/home/sopel/.local/bin:${PATH}"
+
 # Set arguments/flags for sopel command
 if [ "${#}" -eq 0 ] || [ "${1#-}" != "${1}" ]; then
   set -- sopel "${@}"
+fi
+
+if [ "${1}" = "sopel" ]; then
+  exec su-exec sopel "${@}"
+fi
+
+if [ -n "${USER}" ]; then
+  set -- su-exec "${USER}" "${@}"
 fi
 
 exec "${@}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,23 @@ set -e
 
 export PATH="/home/sopel/.local/bin:${PATH}"
 
+# Define functions
+change_uid () {
+  NEW_UID="${1}"
+  echo -n "Setting UID for user sopel to ${NEW_UID}... "
+  (usermod -u "${NEW_UID}" sopel && echo "Done.") || (echo "FAILED!" && return 1)
+}
+
+change_gid () {
+  NEW_GID="${1}"
+  echo -n "Setting GID for user sopel to ${NEW_GID}... "
+  (groupmod -g "${NEW_GID}" sopel && echo "Done.") || (echo "FAILED!" && return 1)
+}
+
+# Check if IDs need to be changed
+[ -n "${PUID}" ] && change_uid "${PUID}"
+[ -n "${PGID}" ] && change_gid "${PGID}"
+
 # Set arguments/flags for sopel command
 if [ "${#}" -eq 0 ] || [ "${1#-}" != "${1}" ]; then
   set -- sopel "${@}"


### PR DESCRIPTION
Here's the plan:

- [x] Run image as `root`, and drop to `sopel` user with `su-exec` (alpine)
- [x] Read `PUID` and `PGID` environment variables to set user `sopel` ids at start-up

Fixes #12 