### PR TITLE
build: allow extra `build-arg`s in build hook

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -27,5 +27,6 @@ docker build \
   --build-arg BUILD_DATE="${BUILD_DATE}" \
   --build-arg VCS_REF="${VCS_REF}" \
   --build-arg DOCKERFILE_VCS_REF="${DOCKERFILE_VCS_REF}" \
-  -f "${DOCKERFILE_PATH}" \
+  ${EXTRA_BUILD_ARGS} \
+  -f "${DOCKERFILE_PATH:-./Dockerfile}" \
   -t "${IMAGE_NAME}" .


### PR DESCRIPTION
During development/testing, it can be useful to run commands that help with cache reuse and specific-version image generation.

e.g., `PYTHON_TAG="2.7-alpine" SOPEL_BRANCH="v6.6.0" BUILD_DATE="-" DOCKERFILE_PATH="./Dockerfile" IMAGE_NAME="test/sopel:py2.7-v6.6.0" ./hooks/build` will create an image with `Sopel v6.6.0` tag from the main repo in a `Python 2.7-alpine` environment (tags match [Docker Hub /_/python](https://hub.docker.com/_/python)).

`EXTRA_BUILD_ARGS` variable can now be set to pass extra `--build-arg`s to the `docker build` command to specify less common `ARG`s like `SOPEL_REPO`. Also, now `DOCKERFILE_PATH` has a default (`./Dockerfile`). So now, you can also build specific snapshots of any Sopel repo:

e.g., `PYTHON_TAG=3.6-alpine EXTRA_BUILD_ARGS="--build-arg SOPEL_REPO=https://github.com/HumorBaby/sopel.git" SOPEL_BRANCH="feat-show-python-version" IMAGE_NAME="test/sopel:py3.6-my_custom_branch" ./hooks/build`