### PR TITLE
style: remove commented commands in `RUN` for python 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,10 +91,6 @@ WORKDIR /home/sopel
 
 COPY --from=git-fetch --chown=sopel:sopel /sopel-src /home/sopel/sopel-src
 RUN set -ex \
-  ## If using a Python 2 based base-image, make sure to install the required
-  ## dependencies (uncomment below)
-  # && pip install --user \
-  #   backports.ssl_match_hostname \
   && cd ./sopel-src \
   && su-exec sopel python setup.py install --user \
   && cd .. \


### PR DESCRIPTION
... turns out that the `backports.ssl_match_hostname` is not needed for Python 2 images because its already available.

Closes #10